### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-unstructured
+unstructured[pdf]
 sentence_transformers
 qdrant_client
 uuid


### PR DESCRIPTION
[pdf] required to resolve error `ImportError: partition_pdf is not available. Install the pdf dependencies with pip install "unstructured[pdf]"`